### PR TITLE
Improve error handling with structured logging

### DIFF
--- a/InOffExpense/ViewModels/DashboardViewVM.swift
+++ b/InOffExpense/ViewModels/DashboardViewVM.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import os
 
 @MainActor
 final class DashboardViewVM: ObservableObject {
@@ -17,6 +18,7 @@ final class DashboardViewVM: ObservableObject {
     private let expenseService: ExpenseServiceProtocol
     private let budgetService: BudgetServiceProtocol
     private var undoStack: [DeletedExpenseRecord] = []
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "InOffExpense", category: "DashboardViewVM")
     
     @Published var allExpenses: [Expense] = []
     @Published var budgets: [Budget] = []
@@ -55,7 +57,7 @@ final class DashboardViewVM: ObservableObject {
             let budget = try budgetService.createDefaultBudget()
             displayedBudget = budget.currentBudget
         } catch {
-            print("Error creating default budget: \(error)")
+            logger.error("Error creating default budget: \(error.localizedDescription)")
         }
     }
     
@@ -75,7 +77,7 @@ final class DashboardViewVM: ObservableObject {
             undoStack.append(record)
             showUndoBanner = true
         } catch {
-            print("Error deleting expense: \(error)")
+            logger.error("Error deleting expense: \(error.localizedDescription)")
         }
     }
     
@@ -90,7 +92,7 @@ final class DashboardViewVM: ObservableObject {
             try expenseService.updateExpense(expense)
             try budgetService.updateBudget(budget)
         } catch {
-            print("Error marking as paid: \(error)")
+            logger.error("Error marking as paid: \(error.localizedDescription)")
         }
     }
     
@@ -107,7 +109,7 @@ final class DashboardViewVM: ObservableObject {
             
             try expenseService.createExpense(record.expense)
         } catch {
-            print("Error undoing delete: \(error)")
+            logger.error("Error undoing delete: \(error.localizedDescription)")
         }
     }
     

--- a/InOffExpense/Views/ExpenseEditingView.swift
+++ b/InOffExpense/Views/ExpenseEditingView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import SwiftData
 import PhotosUI
+import os
 
 struct ExpenseEditingView: View {
     @Environment(\.modelContext) private var modelContext
@@ -10,6 +11,7 @@ struct ExpenseEditingView: View {
     @State private var originalAmount: Double
     @State private var selectedPhotoItem: PhotosPickerItem?
     @State private var showCategoryPicker = false
+    private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "InOffExpense", category: "ExpenseEditingView")
 
     init(expense: Expense) {
         self.expense = expense
@@ -116,7 +118,7 @@ struct ExpenseEditingView: View {
             NotificationCenter.default.post(name: Notification.Name("ExpenseUpdated"), object: nil)
             dismiss()
         } catch {
-            print("Error saving edited expense: \(error)")
+            logger.error("Error saving edited expense: \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `Logger` instances in `DashboardViewVM` and `ExpenseEditingView`
- replace `print` error handling with structured logging

## Testing
- `grep -n "print(" -r InOffExpense`