### PR TITLE
Fix expense row swipe gesture

### DIFF
--- a/InOffExpense/Views/DashBoardView.swift
+++ b/InOffExpense/Views/DashBoardView.swift
@@ -216,14 +216,18 @@ private struct ExpenseRow: View {
     let onMarkAsPaid: (Expense) -> Void
     
     var body: some View {
-        NavigationLink {
-            ExpenseEditingView(expense: expense)
-        } label: {
+        ZStack {
+            // Hidden navigation link so the row remains swipeable
+            NavigationLink(destination: ExpenseEditingView(expense: expense)) {
+                EmptyView()
+            }
+            .opacity(0)
+
             HStack(spacing: 0) {
                 Rectangle()
                     .fill(Color.categoryColor(for: expense.category))
                     .frame(width: 4)
-                
+
                 HStack {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(expense.supplier?.name ?? "Unknown Supplier")
@@ -258,9 +262,12 @@ private struct ExpenseRow: View {
             .background(Color(.systemBackground))
             .clipShape(RoundedRectangle(cornerRadius: 12))
             .shadow(color: .black.opacity(0.06), radius: 5, x: 0, y: 2)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+        // Allow a full swipe gesture to immediately delete the expense card
+        // without requiring the user to tap the Delete button.
+        .swipeActions(edge: .trailing) {
             Button(role: .destructive) {
                 let generator = UIImpactFeedbackGenerator(style: .rigid)
                 generator.impactOccurred()

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ InOffExpense is an iOS application for tracking business expenses. It lets you l
 - Launch the app and tap **+** to log an expense. Provide a supplier name, amount, category and any additional details.
 - Use the dashboard to review recent expenses and your remaining budget.
 - When an expense is marked as paid, small "orb" animations travel from the budget pill to the spent pill to visualize the budget reduction.
+- Swipe left on an expense card to quickly delete it with a full swipe gesture.
 - Navigate through the Statistics view to see charts of your weekly spending.
 
 ## Credits


### PR DESCRIPTION
## Summary
- make expense rows swipeable by hiding the `NavigationLink` inside a `ZStack`
- update bullet about swiping in README

## Testing
- `swift --version`
